### PR TITLE
Log messages 'No default constructor for' at DEBUG level

### DIFF
--- a/src/one/nio/serial/CollectionSerializer.java
+++ b/src/one/nio/serial/CollectionSerializer.java
@@ -137,8 +137,9 @@ public class CollectionSerializer extends Serializer<Collection> {
         }
 
         generateUid();
-        Repository.log.warn("[" + Long.toHexString(uid) + "] No default constructor for " + descriptor +
-                ", changed type to " + implementation.getName());
+        if (Repository.log.isDebugEnabled()) {
+            Repository.log.debug("[{}] No default constructor for {}, changed type to {}", Long.toHexString(uid), descriptor, implementation.getName());
+        }
 
         try {
             return MethodHandles.publicLookup()


### PR DESCRIPTION
This messages flood logs especially during unit tests. At the same time you shall not react on them, because its not harmful for application logic.